### PR TITLE
Add debug endpoints for Google auth

### DIFF
--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -108,6 +108,13 @@ builder.Services.AddAuthentication()
         options.ClientSecret = builder.Configuration["OAuth:ClientSecret"];
         options.CallbackPath = "/signin-google";
         options.ClaimActions.MapJsonKey("urn:google:picture", "picture", "url");
+    })
+    .AddGoogle("GoogleDebug", options =>
+    {
+        options.ClientId = builder.Configuration["OAuth:ClientID"];
+        options.ClientSecret = builder.Configuration["OAuth:ClientSecret"];
+        options.CallbackPath = "/signin-google-debug";
+        options.ClaimActions.MapJsonKey("urn:google:picture", "picture", "url");
     });
 
 // 🍪 Cookies


### PR DESCRIPTION
## Summary
- add a second Google auth scheme for debugging
- add `/account/login-google-debug` and `/account/signin-google-debug`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868887633708330914afb427222c753