### PR TITLE
Enable Google debug endpoints

### DIFF
--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -108,6 +108,8 @@ builder.Services.AddAuthentication(options =>
     options.ClientSecret = builder.Configuration["OAuth:ClientSecret"];
     options.CallbackPath = "/account/signin-google";
     options.ClaimActions.MapJsonKey("urn:google:picture", "picture", "url");
+    options.CorrelationCookie.SameSite = SameSiteMode.None;
+    options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
 });
 
 // 🔑 Data Protection – persistencia de claves para reset de contraseña


### PR DESCRIPTION
## Summary
- add Google debug endpoint and debug output in AccountController
- ensure correlation cookies are cross-site safe

## Testing
- `dotnet test alquimia.Tests/alquimia.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_68693b241ef48330a65057b8beda49a6