### PR TITLE
Enable Google debug endpoints

### DIFF
--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -115,33 +115,57 @@ namespace alquimia.Api.Controllers
         }
 
 [HttpGet("login-google")]
-public IActionResult LoginWithGoogle()
+public IActionResult LoginWithGoogle([FromQuery] bool debug = false)
 {
-var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
-_logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", redirectUrl);
-var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
-return Challenge(properties, "Google");
-
+    var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
+    _logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", redirectUrl);
+    var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
+    if (debug)
+    {
+        return Ok(new
+        {
+            redirectUrl,
+            callback = redirectUrl
+        });
+    }
+    return Challenge(properties, "Google");
 
 }
 
         [HttpGet("signin-google")]
-        public async Task<IActionResult> GoogleLoginCallback()
+        public async Task<IActionResult> GoogleLoginCallback([FromQuery] bool debug = false)
         {
             _logger.LogInformation("Callback de login con Google recibido");
             var info = await _signInManager.GetExternalLoginInfoAsync();
             if (info == null)
             {
                 _logger.LogError("Fallo al obtener la información de login externo.");
+                if (debug)
+                    return BadRequest(new { mensaje = "No se pudo obtener la información externa." });
                 return Redirect("http://localhost:3000/Login?error=callback");
             }
 
-
             var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false);
+
+            var frontendRedirect = _config["OAuth:Url"] ?? "https://frontend-alquimia.vercel.app/Login/RedirectGoogle";
 
             if (result.Succeeded)
             {
-              return Redirect("https://frontend-alquimia.vercel.app/Login/RedirectGoogle");
+                var existingUser = await _userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+                var rolesExisting = await _userManager.GetRolesAsync(existingUser);
+                var tokenExisting = _jwtService.GenerateToken(existingUser, rolesExisting);
+                await _signInManager.SignInAsync(existingUser, isPersistent: false);
+                if (debug)
+                {
+                    return Ok(new
+                    {
+                        token = tokenExisting,
+                        existingUser = true,
+                        email = info.Principal.FindFirstValue(ClaimTypes.Email),
+                        name = info.Principal.FindFirstValue(ClaimTypes.Name)
+                    });
+                }
+                return Redirect(frontendRedirect);
             }
 
             // Crear el usuario si no existe
@@ -153,7 +177,7 @@ return Challenge(properties, "Google");
                 Email = email,
                 UserName = GenerateUserNameSeguro(email),
                 Name = name,
-                SecurityStamp = Guid.NewGuid().ToString() // ✅ agregado
+                SecurityStamp = Guid.NewGuid().ToString()
             };
 
             var createResult = await _userManager.CreateAsync(newUser);
@@ -164,7 +188,31 @@ return Challenge(properties, "Google");
             await _userManager.AddLoginAsync(newUser, info);
             await _signInManager.SignInAsync(newUser, isPersistent: false);
             _logger.LogInformation("Google login info recibida para: {Email}", info.Principal.FindFirstValue(ClaimTypes.Email));
-            return Redirect("http://localhost:3000/Login/RedirectGoogle");
+            if (debug)
+            {
+                return Ok(new
+                {
+                    token,
+                    newUser = true,
+                    email,
+                    name
+                });
+            }
+            return Redirect(frontendRedirect);
+        }
+
+        [HttpGet("debug/google-config")]
+        public IActionResult GoogleConfigDebug()
+        {
+            var loginEndpoint = Url.Action("LoginWithGoogle", "Account", null, Request.Scheme);
+            var callback = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
+            return Ok(new
+            {
+                clientIdDefined = !string.IsNullOrWhiteSpace(_config["OAuth:ClientID"]),
+                loginEndpoint,
+                callback,
+                frontendRedirect = _config["OAuth:Url"]
+            });
         }
         [HttpPost("register-provider")]
         public async Task<IActionResult> RegisterProvider([FromBody] RegisterProviderDTO dto)

--- a/alquimia.Api/Middlewares/ErrorHandlingMiddleware.cs
+++ b/alquimia.Api/Middlewares/ErrorHandlingMiddleware.cs
@@ -59,6 +59,13 @@ namespace alquimia.Api.Middlewares
                         : exception.Message;
                     break;
 
+                case InvalidOperationException:
+                    status = (int)HttpStatusCode.InternalServerError; //500
+                    error = string.IsNullOrWhiteSpace(exception.Message)
+                        ? "Ocurrió un error inesperado."
+                        : exception.Message;
+                    break;
+
                 default:
                     status = (int)HttpStatusCode.InternalServerError; //500
                     error = "Ocurrió un error inesperado. Intente más tarde.";

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -108,6 +108,8 @@ builder.Services.AddAuthentication(options =>
     options.ClientSecret = builder.Configuration["OAuth:ClientSecret"];
     options.CallbackPath = "/account/signin-google";
     options.ClaimActions.MapJsonKey("urn:google:picture", "picture", "url");
+    options.CorrelationCookie.SameSite = SameSiteMode.None;
+    options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
 });
 
 // 🔑 Data Protection – persistencia de claves para reset de contraseña
@@ -219,6 +221,8 @@ app.UseRouting();
 app.UseCors("FrontendPolicy");
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
 
 app.MapControllers();
 

--- a/alquimia.Services/JWTService.cs
+++ b/alquimia.Services/JWTService.cs
@@ -31,7 +31,13 @@ new Claim("name", user.Name ?? string.Empty)
                 claims.Add(new Claim(ClaimTypes.Role, role));
             }
 
-            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+            var keyString = _config["Jwt:Key"];
+            if (string.IsNullOrWhiteSpace(keyString))
+            {
+                throw new InvalidOperationException("JWT signing key not configured");
+            }
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyString));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
             var token = new JwtSecurityToken(


### PR DESCRIPTION
## Summary
- add Google login debug info and token response
- add health check endpoint for debugging
- configure OAuth cookie correlation options
- throw helpful error when JWT key is missing and surface message via middleware

## Testing
- `dotnet test alquimia.Tests/alquimia.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68693b241ef48330a65057b8beda49a6