### PR TITLE
Enable Google debug endpoints

### DIFF
--- a/.github/workflows/alquimia-backend-deploy.yml
+++ b/.github/workflows/alquimia-backend-deploy.yml
@@ -1,0 +1,91 @@
+name: Build and deploy ASP.NET Core app to Azure Web App - Alquimia-deploy-back
+
+on:
+  push:
+    branches: [ rama-develop-pre-presentacion ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build project
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Publish project
+        run: dotnet publish -c Release -o ./publish --no-build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-app
+          path: ./publish
+
+  deploy:
+    runs-on: windows-latest
+    needs: build
+    environment:
+      name: Production
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dotnet-app
+
+      - name: Login to Azure (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id:      ${{ secrets.AZUREAPPSERVICE_CLIENTID }}
+          tenant-id:      ${{ secrets.AZUREAPPSERVICE_TENANTID }}
+          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID }}
+
+      - name: Set Azure App Settings & Connection Strings
+        uses: azure/appservice-settings@v1
+        with:
+          app-name: Alquimia-deploy-back
+          app-settings-json: >-
+            [
+              { "name": "Jwt__Key", "value": "${{ secrets.JWT_SECRET_KEY }}", "slotSetting": false },
+              { "name": "Jwt__Issuer", "value": "AlquimiaAPI", "slotSetting": false },
+              { "name": "Jwt__Audience", "value": "AlquimiaFrontend", "slotSetting": false },
+              { "name": "Jwt__DurationInMinutes", "value": "60", "slotSetting": false },
+              { "name": "OAuth__ClientID", "value": "${{ secrets.GOOGLE_CLIENT_ID }}", "slotSetting": false },
+              { "name": "OAuth__ClientSecret", "value": "${{ secrets.GOOGLE_CLIENT_SECRET }}", "slotSetting": false },
+              { "name": "OAuth__Url", "value": "https://tudominio.com/Login/RedirectGoogle", "slotSetting": false },
+              { "name": "Email__User", "value": "${{ secrets.EMAIL_USER }}", "slotSetting": false },
+              { "name": "Email__Password", "value": "${{ secrets.EMAIL_PASSWORD }}", "slotSetting": false },
+              { "name": "Email__From", "value": "${{ secrets.EMAIL_FROM }}", "slotSetting": false },
+              { "name": "MercadoPago__AccessToken", "value": "${{ secrets.MP_ACCESS_TOKEN }}", "slotSetting": false },
+              { "name": "MercadoPago__PublicKey", "value": "${{ secrets.MP_PUBLIC_KEY }}", "slotSetting": false }
+            ]
+          connection-strings-json: >-
+            [
+              {
+                "name": "DefaultConnection",
+                "value": "Server=tcp:alquimiadb.database.windows.net,1433;Initial Catalog=alquimiaDB1;Persist Security Info=False;User ID=alquimia;Password=${{ secrets.DB_PASSWORD }};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=60",
+                "type": "SQLAzure",
+                "slotSetting": false
+              }
+            ]
+
+      - name: Deploy to Azure Web App
+        id: deploy
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: Alquimia-deploy-back
+          slot-name: Production
+          package: .

--- a/.github/workflows/alquimia-backend-deploy.yml
+++ b/.github/workflows/alquimia-backend-deploy.yml
@@ -65,7 +65,7 @@ jobs:
               { "name": "Jwt__DurationInMinutes", "value": "60", "slotSetting": false },
               { "name": "OAuth__ClientID", "value": "${{ secrets.GOOGLE_CLIENT_ID }}", "slotSetting": false },
               { "name": "OAuth__ClientSecret", "value": "${{ secrets.GOOGLE_CLIENT_SECRET }}", "slotSetting": false },
-              { "name": "OAuth__Url", "value": "https://tudominio.com/Login/RedirectGoogle", "slotSetting": false },
+              { "name": "OAuth__Url", "value": "https://alquimia-deploy-back-a8dqhub8ekdff8dk.brazilsouth-01.azurewebsites.net/account/signin-google", "slotSetting": false },
               { "name": "Email__User", "value": "${{ secrets.EMAIL_USER }}", "slotSetting": false },
               { "name": "Email__Password", "value": "${{ secrets.EMAIL_PASSWORD }}", "slotSetting": false },
               { "name": "Email__From", "value": "${{ secrets.EMAIL_FROM }}", "slotSetting": false },

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,43 @@
+name: Keep Alive
+
+on:
+  workflow_dispatch:           # 👈 Ejecutar manualmente desde GitHub
+  schedule:
+    - cron: '*/5 * * * *'      # 🕐 Cada 5 minutos
+
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Azure backend con diagnóstico
+        run: |
+          URL="https://alquimia-deploy-back-a8dqhub8ekdff8dk.brazilsouth-01.azurewebsites.net/health"
+          echo "🔄 Haciendo ping a $URL..."
+          
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 "$URL")
+          echo "📡 Código de respuesta: $RESPONSE"
+
+          if [ "$RESPONSE" -eq 200 ]; then
+            echo "✅ Backend OK"
+          else
+            echo "❌ Algo falló..."
+            case $RESPONSE in
+              000)
+                echo "::error ::No hubo respuesta (timeout, dominio incorrecto o backend muy dormido)"
+                ;;
+              404)
+                echo "::error ::404: Ruta no encontrada (/health no existe o mal configurado)"
+                ;;
+              503)
+                echo "::error ::503: Servicio no disponible (posiblemente en sleep mode o reiniciando)"
+                ;;
+              500)
+                echo "::error ::500: Error interno en el servidor"
+                ;;
+              *)
+                echo "::error ::Falla inesperada. Código HTTP: $RESPONSE"
+                ;;
+            esac
+            exit 1
+          fi

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -117,8 +117,10 @@ namespace alquimia.Api.Controllers
 [HttpGet("login-google")]
 public IActionResult LoginWithGoogle()
 {
-    var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
-    var absoluteRedirectUri = $"{Request.Scheme}://{Request.Host}{redirectUrl}";
+var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
+_logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", redirectUrl);
+var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
+return Challenge(properties, "Google");
 
     return Content($"Redirect URI: {absoluteRedirectUri}");
 }

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -122,7 +122,7 @@ _logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}
 var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
 return Challenge(properties, "Google");
 
-    return Content($"Redirect URI: {absoluteRedirectUri}");
+
 }
 
         [HttpGet("signin-google")]

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -120,10 +120,7 @@ public IActionResult LoginWithGoogle()
     var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
     var absoluteRedirectUri = $"{Request.Scheme}://{Request.Host}{redirectUrl}";
 
-    _logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", absoluteRedirectUri);
-
-    var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", absoluteRedirectUri);
-    return Challenge(properties, "Google");
+    return Content($"Redirect URI: {absoluteRedirectUri}");
 }
 
         [HttpGet("signin-google")]

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -141,7 +141,7 @@ return Challenge(properties, "Google");
 
             if (result.Succeeded)
             {
-                return Redirect("http://localhost:3000/login/redirectgoogle");
+              return Redirect("https://frontend-alquimia.vercel.app/Login/RedirectGoogle");
             }
 
             // Crear el usuario si no existe

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -114,12 +114,15 @@ namespace alquimia.Api.Controllers
             return Ok(new { mensaje = "Login exitoso ✅", token });
         }
 
- [HttpGet("login-google")]
+[HttpGet("login-google")]
 public IActionResult LoginWithGoogle()
 {
-    var redirectUrl = Url.Action("GoogleLoginCallback", "Account");
-    _logger.LogInformation("🔁 redirect_uri usado: {RedirectUrl}", redirectUrl);
-    var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
+    var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
+    var absoluteRedirectUri = $"{Request.Scheme}://{Request.Host}{redirectUrl}";
+
+    _logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", absoluteRedirectUri);
+
+    var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", absoluteRedirectUri);
     return Challenge(properties, "Google");
 }
 

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -114,13 +114,14 @@ namespace alquimia.Api.Controllers
             return Ok(new { mensaje = "Login exitoso ✅", token });
         }
 
-        [HttpGet("login-google")]
-        public IActionResult LoginWithGoogle()
-        {
-            var redirectUrl = Url.Action("GoogleLoginCallback", "Cuenta");
-            var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
-            return Challenge(properties, "Google");
-        }
+ [HttpGet("login-google")]
+public IActionResult LoginWithGoogle()
+{
+    var redirectUrl = Url.Action("GoogleLoginCallback", "Account");
+    _logger.LogInformation("🔁 redirect_uri usado: {RedirectUrl}", redirectUrl);
+    var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
+    return Challenge(properties, "Google");
+}
 
         [HttpGet("signin-google")]
         public async Task<IActionResult> GoogleLoginCallback()

--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -114,34 +114,64 @@ namespace alquimia.Api.Controllers
             return Ok(new { mensaje = "Login exitoso ✅", token });
         }
 
-[HttpGet("login-google")]
-public IActionResult LoginWithGoogle()
-{
-var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
-_logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", redirectUrl);
-var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
-return Challenge(properties, "Google");
+        [HttpGet("login-google")]
+        public IActionResult LoginWithGoogle([FromQuery] bool debug = false)
+        {
+            var redirectUrl = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
+            _logger.LogInformation("🔁 redirect_uri usado para Google OAuth: {RedirectUrl}", redirectUrl);
+            var properties = _signInManager.ConfigureExternalAuthenticationProperties("Google", redirectUrl);
+            if (debug)
+            {
+                return Ok(new
+                {
+                    redirectUrl,
+                    callback = redirectUrl
+                });
+            }
+            return Challenge(properties, "Google");
 
-
-}
+        }
 
         [HttpGet("signin-google")]
-        public async Task<IActionResult> GoogleLoginCallback()
+        public async Task<IActionResult> GoogleLoginCallback([FromQuery] bool debug = false)
         {
             _logger.LogInformation("Callback de login con Google recibido");
             var info = await _signInManager.GetExternalLoginInfoAsync();
             if (info == null)
             {
                 _logger.LogError("Fallo al obtener la información de login externo.");
+                if (debug)
+                    return BadRequest(new { mensaje = "No se pudo obtener la información externa." });
                 return Redirect("http://localhost:3000/Login?error=callback");
             }
 
-
             var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false);
+
+            var frontendRedirect = _config["OAuth:Url"];
+            if (string.IsNullOrWhiteSpace(frontendRedirect) ||
+                frontendRedirect.Contains("/account/signin-google", StringComparison.OrdinalIgnoreCase))
+            {
+                var baseUrl = _config["AppSettings:FrontendBaseUrl"] ?? "https://frontend-alquimia.vercel.app/";
+                frontendRedirect = baseUrl.TrimEnd('/') + "/Login/RedirectGoogle";
+            }
 
             if (result.Succeeded)
             {
-              return Redirect("https://frontend-alquimia.vercel.app/Login/RedirectGoogle");
+                var existingUser = await _userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+                var rolesExisting = await _userManager.GetRolesAsync(existingUser);
+                var tokenExisting = _jwtService.GenerateToken(existingUser, rolesExisting);
+                await _signInManager.SignInAsync(existingUser, isPersistent: false);
+                if (debug)
+                {
+                    return Ok(new
+                    {
+                        token = tokenExisting,
+                        existingUser = true,
+                        email = info.Principal.FindFirstValue(ClaimTypes.Email),
+                        name = info.Principal.FindFirstValue(ClaimTypes.Name)
+                    });
+                }
+                return Redirect(frontendRedirect);
             }
 
             // Crear el usuario si no existe
@@ -153,7 +183,7 @@ return Challenge(properties, "Google");
                 Email = email,
                 UserName = GenerateUserNameSeguro(email),
                 Name = name,
-                SecurityStamp = Guid.NewGuid().ToString() // ✅ agregado
+                SecurityStamp = Guid.NewGuid().ToString()
             };
 
             var createResult = await _userManager.CreateAsync(newUser);
@@ -164,7 +194,58 @@ return Challenge(properties, "Google");
             await _userManager.AddLoginAsync(newUser, info);
             await _signInManager.SignInAsync(newUser, isPersistent: false);
             _logger.LogInformation("Google login info recibida para: {Email}", info.Principal.FindFirstValue(ClaimTypes.Email));
-            return Redirect("http://localhost:3000/Login/RedirectGoogle");
+            if (debug)
+            {
+                return Ok(new
+                {
+                    token,
+                    newUser = true,
+                    email,
+                    name
+                });
+            }
+            return Redirect(frontendRedirect);
+        }
+
+        [HttpGet("debug/google-config")]
+        public IActionResult GoogleConfigDebug()
+        {
+            var loginEndpoint = Url.Action("LoginWithGoogle", "Account", null, Request.Scheme);
+            var callback = Url.Action("GoogleLoginCallback", "Account", null, Request.Scheme);
+            var frontendRedirect = _config["OAuth:Url"];
+            if (string.IsNullOrWhiteSpace(frontendRedirect) ||
+                frontendRedirect.Contains("/account/signin-google", StringComparison.OrdinalIgnoreCase))
+            {
+                var baseUrl = _config["AppSettings:FrontendBaseUrl"] ?? "https://frontend-alquimia.vercel.app/";
+                frontendRedirect = baseUrl.TrimEnd('/') + "/Login/RedirectGoogle";
+            }
+            return Ok(new
+            {
+                clientIdDefined = !string.IsNullOrWhiteSpace(_config["OAuth:ClientID"]),
+                loginEndpoint,
+                callback,
+                frontendRedirect
+            });
+        }
+
+        [HttpGet("debug/google-login")]
+        public IActionResult GoogleLoginDebug()
+        {
+            var loginUrl = Url.Action("LoginWithGoogle", "Account", new { debug = true }, Request.Scheme);
+            var callbackUrl = Url.Action("GoogleLoginCallback", "Account", new { debug = true }, Request.Scheme);
+            var frontendRedirect = _config["OAuth:Url"];
+            if (string.IsNullOrWhiteSpace(frontendRedirect) ||
+                frontendRedirect.Contains("/account/signin-google", StringComparison.OrdinalIgnoreCase))
+            {
+                var baseUrl = _config["AppSettings:FrontendBaseUrl"] ?? "https://frontend-alquimia.vercel.app/";
+                frontendRedirect = baseUrl.TrimEnd('/') + "/Login/RedirectGoogle";
+            }
+            return Ok(new
+            {
+                loginUrl,
+                callbackUrl,
+                frontendRedirect
+            });
         }
         [HttpPost("register-provider")]
         public async Task<IActionResult> RegisterProvider([FromBody] RegisterProviderDTO dto)

--- a/alquimia.Api/Middlewares/ErrorHandlingMiddleware.cs
+++ b/alquimia.Api/Middlewares/ErrorHandlingMiddleware.cs
@@ -59,6 +59,13 @@ namespace alquimia.Api.Middlewares
                         : exception.Message;
                     break;
 
+                case InvalidOperationException:
+                    status = (int)HttpStatusCode.InternalServerError; //500
+                    error = string.IsNullOrWhiteSpace(exception.Message)
+                        ? "Ocurrió un error inesperado."
+                        : exception.Message;
+                    break;
+
                 default:
                     status = (int)HttpStatusCode.InternalServerError; //500
                     error = "Ocurrió un error inesperado. Intente más tarde.";

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -177,7 +177,7 @@ builder.Services.Configure<IdentityOptions>(options =>
     options.User.RequireUniqueEmail = true;
 });
 
-builder.Services.AddApplicationInsightsTelemetry();
+
 
 // 🏁 Build y Middleware
 var app = builder.Build();

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -1,11 +1,9 @@
-﻿
 using alquimia.Api.Middlewares;
 using alquimia.Api.Seed;
 using alquimia.Data.Entities;
 using alquimia.Services;
 using alquimia.Services.Handler;
 using alquimia.Services.Interfaces;
-using alquimia.Services.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
@@ -13,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Text;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,11 +20,10 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddDbContext<AlquimiaDbContext>(options =>
 {
     options.UseSqlServer(connectionString);
-    options.EnableSensitiveDataLogging(); // 👈 para debug
+    options.EnableSensitiveDataLogging(); // Debugging
 });
 
-builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("Email"));
-
+// 💡 Servicios y dependencias
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IProductService, ProductService>();
@@ -37,7 +35,8 @@ builder.Services.AddScoped<IAdminService, AdminService>();
 builder.Services.AddScoped<IProfileService, ProfileService>();
 builder.Services.AddScoped<IOlfactoryFamilyService, OlfactoryFamilyService>();
 builder.Services.AddScoped<IDesignLabelService, DesignLabelService>();
-builder.Services.AddScoped<IEmailService, EmailService>();
+builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>(); // ✅ Registro agregado
+builder.Services.AddTransient<IEmailService, EmailService>();
 builder.Services.AddScoped<IMercadoPagoService, MercadoPagoService>();
 builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>();
 builder.Services.AddScoped<IChatbotService, ChatbotService>();
@@ -63,6 +62,7 @@ builder.Services.AddScoped<IChatDynamicNodeHandler, DinamicStateProviderHelp>();
 //        options.JsonSerializerOptions.PropertyNamingPolicy = null;
 //    });
 
+// 🧩 Controladores
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
     {
@@ -71,11 +71,12 @@ builder.Services.AddControllers()
         options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
     });
 
+// 🔐 Identity
 builder.Services.AddIdentity<User, Role>()
     .AddEntityFrameworkStores<AlquimiaDbContext>()
     .AddDefaultTokenProviders();
 
-// 🔐 JWT Authentication
+// 🔐 JWT
 var jwtSettings = builder.Configuration.GetSection("Jwt");
 var key = Encoding.ASCII.GetBytes(jwtSettings["Key"]);
 
@@ -100,7 +101,7 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
-// 🌐 Google Authentication (opcional)
+// 🌐 Google Auth
 builder.Services.AddAuthentication()
     .AddGoogle(options =>
     {
@@ -123,7 +124,6 @@ builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "Alquimia API", Version = "v1" });
 
-    // 🔐 Configuración para JWT
     c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Description = @"JWT Authorization header usando el esquema Bearer.  
@@ -134,7 +134,7 @@ builder.Services.AddSwaggerGen(c =>
         Scheme = "Bearer"
     });
 
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
     {
         {
             new OpenApiSecurityScheme
@@ -153,15 +153,16 @@ builder.Services.AddSwaggerGen(c =>
     });
 });
 
-// 🔓 CORS
+// 🔓 CORS incluyendo Vercel
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("FrontendPolicy", policy =>
     {
         policy.WithOrigins(
-            "http://localhost:3000",    // Next.js dev server
-            "https://localhost:5035",   // Swagger
-            "https://localhost:5173"    // Vite auth
+            "http://localhost:3000",                          // Next.js dev
+            "https://localhost:5035",                         // Swagger
+            "https://localhost:5173",                         // Vite dev
+            "https://frontend-alquimia.vercel.app"           // ✅ Producción en Vercel
         )
         .AllowAnyHeader()
         .AllowAnyMethod()
@@ -169,25 +170,31 @@ builder.Services.AddCors(options =>
     });
 });
 
+// ⚙️ Configuración de Identity
 builder.Services.Configure<IdentityOptions>(options =>
 {
     options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+";
     options.User.RequireUniqueEmail = true;
 });
 
+builder.Services.AddApplicationInsightsTelemetry();
+
 // 🏁 Build y Middleware
 var app = builder.Build();
+
 app.UseMiddleware<ErrorHandlingMiddleware>();
 
+// 🧪 Seeders
 using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
     await RoleSeeder.SeedRolesAsync(services);
     await UserSeeder.SeedAdminAsync(services);
     await ProductSeeder.SeedTiposProductoAsync(services);
-    //await UserSeeder.SeedProveedoresAsync(services);
+    // await UserSeeder.SeedProveedoresAsync(services); // Descomenta si lo necesitás
 }
 
+// 📚 Swagger UI
 app.UseSwagger();
 app.UseSwaggerUI(c =>
 {
@@ -196,8 +203,8 @@ app.UseSwaggerUI(c =>
 });
 
 app.UseStaticFiles();
-app.UseCors("FrontendPolicy");
 app.UseRouting();
+app.UseCors("FrontendPolicy"); // ✅ MOVIDO AQUÍ
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddScoped<IDesignLabelService, DesignLabelService>();
 builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>(); // ✅ Registro agregado
 builder.Services.AddTransient<IEmailService, EmailService>();
 builder.Services.AddScoped<IMercadoPagoService, MercadoPagoService>();
-builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>();
+
 builder.Services.AddScoped<IChatbotService, ChatbotService>();
 builder.Services.AddScoped<IChatDynamicNodeHandler, DinamicNotesHandler>();
 builder.Services.AddScoped<IChatDynamicNodeHandler, DinamicTopNotesHandler>();

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -106,7 +106,7 @@ builder.Services.AddAuthentication(options =>
 {
     options.ClientId = builder.Configuration["OAuth:ClientID"];
     options.ClientSecret = builder.Configuration["OAuth:ClientSecret"];
-    options.CallbackPath = "/signin-google";
+    options.CallbackPath = "/account/signin-google";
     options.ClaimActions.MapJsonKey("urn:google:picture", "picture", "url");
 });
 

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddDbContext<AlquimiaDbContext>(options =>
 });
 
 // 💡 Servicios y dependencias
+builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("Email"));
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IProductService, ProductService>();

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Text;
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -1,5 +1,5 @@
 // Program.cs – Alquimia API (corrigido)
-
+using alquimia.Services.Models;
 using alquimia.Api.Middlewares;
 using alquimia.Api.Seed;
 using alquimia.Data.Entities;

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -1,5 +1,6 @@
 // Program.cs – Alquimia API (corrigido)
 using alquimia.Services.Models;
+using Microsoft.AspNetCore.DataProtection; 
 using alquimia.Api.Middlewares;
 using alquimia.Api.Seed;
 using alquimia.Data.Entities;

--- a/alquimia.Api/Program.cs
+++ b/alquimia.Api/Program.cs
@@ -108,6 +108,8 @@ builder.Services.AddAuthentication(options =>
     options.ClientSecret = builder.Configuration["OAuth:ClientSecret"];
     options.CallbackPath = "/account/signin-google";
     options.ClaimActions.MapJsonKey("urn:google:picture", "picture", "url");
+    options.CorrelationCookie.SameSite = SameSiteMode.None;
+    options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
 });
 
 // 🔑 Data Protection – persistencia de claves para reset de contraseña
@@ -219,6 +221,8 @@ app.UseRouting();
 app.UseCors("FrontendPolicy");
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
 
 app.MapControllers();
 

--- a/alquimia.Api/alquimia.Api.csproj
+++ b/alquimia.Api/alquimia.Api.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="PdfSharpCore" Version="1.3.67" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.2" />
   </ItemGroup>

--- a/alquimia.Api/alquimia.Api.csproj
+++ b/alquimia.Api/alquimia.Api.csproj
@@ -11,8 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />

--- a/alquimia.Api/alquimia.Api.csproj
+++ b/alquimia.Api/alquimia.Api.csproj
@@ -11,6 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />

--- a/alquimia.Api/alquimia.Api.csproj
+++ b/alquimia.Api/alquimia.Api.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="PdfSharpCore" Version="1.3.67" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/alquimia.Api/appsettings.json
+++ b/alquimia.Api/appsettings.json
@@ -13,7 +13,7 @@
   "OAuth": {
     "ClientID": "",
     "ClientSecret": "",
-    "Url": "https://tudominio.com/Login/RedirectGoogle"
+    "Url": "https://frontend-alquimia.vercel.app/Login/RedirectGoogle"
   },
   "Jwt": {
     "Key": "",

--- a/alquimia.Api/appsettings.json
+++ b/alquimia.Api/appsettings.json
@@ -1,0 +1,50 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "TrustServerCertificate": "True",
+  "OAuth": {
+    "ClientID": "",
+    "ClientSecret": "",
+    "Url": "https://tudominio.com/Login/RedirectGoogle"
+  },
+  "Jwt": {
+    "Key": "",
+    "Issuer": "AlquimiaAPI",
+    "Audience": "AlquimiaFrontend",
+    "DurationInMinutes": 60
+  },
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:5035"
+      }
+    }
+  },
+  "Email": {
+    "SmtpHost": "smtp.gmail.com",
+    "SmtpPort": "587",
+    "User": "",
+    "Password": "",
+    "From": ""
+  },
+  "MercadoPago": {
+    "AccessToken": "",
+    "PublicKey": "",
+    "BackUrls": {
+      "Success": "https://pago-exitoso.onrender.com/success.html",
+      "Failure": "https://pago-exitoso.onrender.com/success.html?status=failure",
+      "Pending": "https://pago-exitoso.onrender.com/success.html?status=pending"
+    }
+  },
+  "AppSettings": {
+    "FrontendBaseUrl": "https://frontend-alquimia.vercel.app/"
+  }
+}

--- a/alquimia.Services/JWTService.cs
+++ b/alquimia.Services/JWTService.cs
@@ -31,7 +31,13 @@ new Claim("name", user.Name ?? string.Empty)
                 claims.Add(new Claim(ClaimTypes.Role, role));
             }
 
-            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+            var keyString = _config["Jwt:Key"];
+            if (string.IsNullOrWhiteSpace(keyString))
+            {
+                throw new InvalidOperationException("JWT signing key not configured");
+            }
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyString));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
             var token = new JwtSecurityToken(


### PR DESCRIPTION
## Summary
- add Google login debug info and token response
- add health check endpoint for debugging
- configure OAuth cookie correlation options
- throw helpful error when JWT key is missing and surface message via middleware
- expose Google login/callback paths via debug endpoints
- expand debug login endpoint with frontend redirect info

## Testing
- `dotnet test alquimia.Tests/alquimia.Tests.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693b241ef48330a65057b8beda49a6